### PR TITLE
Option to record entire window

### DIFF
--- a/byzanz-gui
+++ b/byzanz-gui
@@ -3,6 +3,7 @@
 # AUTHOR:   (c) Rob W 2012
 #           modified by MHC (http://askubuntu.com/users/81372/mhc)
 #           and by Rodolfo Carvalho
+#			and by Edridge D'Souza
 # NAME:     GIFRecord 0.1-fedora
 # DESCRIPTION:  A script to record GIF screencasts.
 # LICENSE:  GNU GPL v3 (http://www.gnu.org/licenses/gpl.html)
@@ -17,7 +18,7 @@ TIME=$(date +"%Y-%m-%d_%H%M%S")
 DELAY=10
  
 # Standard screencast folder
-FOLDER="$HOME/Pictures"
+FOLDER="$HOME/Pictures/ByzanzGif"
  
 # Default recording duration
 DEFDUR=10

--- a/byzanz-gui
+++ b/byzanz-gui
@@ -41,7 +41,7 @@ read W < <(awk -F: '/Width/{print $2}' <<< "$XWININFO")
 read H < <(awk -F: '/Height/{print $2}' <<< "$XWININFO")
  
 # Notify the user of recording time and delay
-notify-send "GIFRecorder" "Recording duration set to $D seconds. Recording will start in $DELAY seconds."
+echo "Recording duration set to $D seconds. Recording will start in $DELAY seconds."
  
 #Actual recording
 espeak "Starting in $DELAY seconds."
@@ -51,4 +51,5 @@ byzanz-record -c --verbose --delay=0 --duration=$D --x=$X --y=$Y --width=$W --he
 espeak "Stop"
  
 # Notify the user of end of recording.
+echo "Screencast saved to $FOLDER/GIFrecord_$TIME.gif"
 notify-send "GIFRecorder" "Screencast saved to $FOLDER/GIFrecord_$TIME.gif"

--- a/byzanz-gui
+++ b/byzanz-gui
@@ -35,6 +35,9 @@ fi
  
 # Window geometry
 XWININFO=$(xwininfo)
+
+read TITLE < <(grep -o '".*"'  <<< "$XWININFO")
+TITLE=$(echo $TITLE | sed 's/"//g')
 read X < <(awk -F: '/Absolute upper-left X/{print $2}' <<< "$XWININFO")
 read Y < <(awk -F: '/Absolute upper-left Y/{print $2}' <<< "$XWININFO")
 read W < <(awk -F: '/Width/{print $2}' <<< "$XWININFO")
@@ -47,7 +50,14 @@ echo "Recording duration set to $D seconds. Recording will start in $DELAY secon
 espeak "Starting in $DELAY seconds."
 sleep $DELAY
 espeak "Start"
-byzanz-record -c --verbose --delay=0 --duration=$D --x=$X --y=$Y --width=$W --height=$H "$FOLDER/GIFrecord_$TIME.gif"
+
+if [ $TITLE = "unity-panel" ]; then
+	byzanz-record -c --verbose --delay=0 --duration=$D "$FOLDER/GIFrecord_$TIME.gif"
+
+else
+	byzanz-record -c --verbose --delay=0 --duration=$D --x=$X --y=$Y --width=$W --height=$H "$FOLDER/GIFrecord_$TIME.gif"
+fi
+
 espeak "Stop"
  
 # Notify the user of end of recording.

--- a/byzanz-gui
+++ b/byzanz-gui
@@ -23,11 +23,6 @@ FOLDER="$HOME/Pictures/ByzanzGif"
 # Default recording duration
 DEFDUR=10
  
-# Sound notification to let one know when recording is about to start (and ends)
-beep() {
-    paplay /usr/share/sounds/freedesktop/stereo/message-new-instant.oga &
-}
- 
 # Custom recording duration as set by user
 USERDUR=$(zenity --entry --title "Recoding duration" --text "Please enter the screencast duration in seconds:" --width 200 --height 100 2>/dev/null)
  
@@ -49,10 +44,11 @@ read H < <(awk -F: '/Height/{print $2}' <<< "$XWININFO")
 notify-send "GIFRecorder" "Recording duration set to $D seconds. Recording will start in $DELAY seconds."
  
 #Actual recording
+espeak "Starting in $DELAY seconds."
 sleep $DELAY
-beep
+espeak "Start"
 byzanz-record -c --verbose --delay=0 --duration=$D --x=$X --y=$Y --width=$W --height=$H "$FOLDER/GIFrecord_$TIME.gif"
-beep
+espeak "Stop"
  
 # Notify the user of end of recording.
 notify-send "GIFRecorder" "Screencast saved to $FOLDER/GIFrecord_$TIME.gif"

--- a/byzanz-gui
+++ b/byzanz-gui
@@ -18,7 +18,7 @@ TIME=$(date +"%Y-%m-%d_%H%M%S")
 DELAY=10
  
 # Standard screencast folder
-FOLDER="$HOME/Pictures/ByzanzGif"
+FOLDER=$(xdg-user-dir PICTURES 2>/dev/null || echo "$HOME/Pictures")/ByzanzGif
  
 # Default recording duration
 DEFDUR=10


### PR DESCRIPTION
I made a couple of changes:

1. if you click the unity titlebar, it'll record the entire screen, including the titlebar and dock (Unity only, not tested on other DE's)

2. Uses espeak instead of a notification sound

3. Changed some notifications to simple terminal outputs so they don't interfere with the recording